### PR TITLE
Closes #116 #115 Implementando controller responsável por retornar a quantidade total de notas pendentes e concluidas

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,7 +21,7 @@ app.use(cors());
 
 const limiter = rateLimit({
     windowMs: 20*60*1000,
-    max: 200,
+    max: 3000,
     message: {error: "Limite de requisições excedido, tente novamente mais tarde"},
     headers: true,
 })

--- a/controllers/controllerNotes.js
+++ b/controllers/controllerNotes.js
@@ -137,6 +137,23 @@ async function pesquisaNotas(req, res) {
     }
 }
 
+async function totalNotas (req, res){
+    try {
+        const userId = req.userId;
+
+        if(!userId){
+            return res.status(400).json({msg: "Usuário não informado"});
+        }
+
+        const pendente = await Notes.countDocuments({usuario: userId, status: "pendente"});
+        const concluida = await Notes.countDocuments({usuario: userId, status: "concluida"});
+
+        return res.status(200).json({ pendente, concluida });
+    } catch(error) {
+        return res.status(500).json({msg: "Erro ao buscar quantidade de notas", error});
+    }
+}
+
 
 module.exports = {
     criar,
@@ -144,6 +161,7 @@ module.exports = {
     buscarPeloID,
     obterNota,
     pesquisaNotas,
+    totalNotas,
     remover,
     atualizar,
     validaDados,

--- a/routes/router_notes.js
+++ b/routes/router_notes.js
@@ -5,6 +5,7 @@ const router = express.Router();
 
 router.get("/", middleware.validaToken,controller.listarNotes);
 router.get("/search", middleware.validaToken, controller.pesquisaNotas);
+router.get("/totals", middleware.validaToken, controller.totalNotas);
 router.get("/:id", middleware.validaToken, controller.buscarPeloID, controller.obterNota);
 router.post("/", middleware.validaToken, controller.validaDados,controller.criar);
 router.put("/:id", middleware.validaToken, controller.buscarPeloID, controller.validaDados, controller.atualizar);


### PR DESCRIPTION
-  O número máximo de solicitações por foi alterado de 200 para 3000 na configuração do rate-limit;
- Adicionada uma nova função `totalNotas` para contar e retornar o número de notas pendentes e concluídas para um usuário;
- Adicionada uma nova rota `/totals` que usa a função do controlador `totalNotas` para retornar a quantidade de notas com base no tipo, pendente e concluida.
