### PR TITLE
Fix: remover mensagem de sucesso na resposta ao excluir nota

### DIFF
--- a/controllers/controllerNotes.js
+++ b/controllers/controllerNotes.js
@@ -83,7 +83,7 @@ async function remover(req, res) {
         return res.status(404).json({ msg: 'Nota não encontrada' });
     }
 
-    res.status(204).json({ msg: 'Nota excluída com sucesso!'});
+    res.status(204).end();
 }
 
 async function atualizar(req, res) {


### PR DESCRIPTION
- A alteração modifica a resposta quando uma nota é excluída com sucesso para usar `res.end()` em vez de enviar uma mensagem JSON.;